### PR TITLE
Use router5 in the service worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "mini-css-extract-plugin": "^0.8.0",
     "morgan": "^1.9.1",
     "node-fetch": "^2.6.0",
-    "path-to-regexp": "^3.1.0",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.7.0",
     "react": "^16.9.0",

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,14 +1,17 @@
 /* eslint-env worker */
 
-import pathToRegexp from 'path-to-regexp'
+import {cloneRouter} from 'router5'
 import {createHandlerForURL, precacheAndRoute} from 'workbox-precaching'
-import {NavigationRoute, registerRoute} from 'workbox-routing'
+import {registerRoute} from 'workbox-routing'
 
+import {createRouter, startRouter} from '~/src/routing.js'
 import routes from '~/src/routes.js'
 
-const navigationWhitelist = routes
-  .filter(({isClient = true}) => isClient)
-  .map(({path}) => pathToRegexp(path))
+const routesByName = routes.reduce((routes, route) => {
+  routes[route.name] = route
+
+  return routes
+}, {})
 
 self.addEventListener('message', event => {
   if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting()
@@ -16,11 +19,43 @@ self.addEventListener('message', event => {
 
 precacheAndRoute(self.__WB_MANIFEST)
 
-const handler = createHandlerForURL(findAppShellUrl(self.__WB_MANIFEST))
-const navigationRoute = new NavigationRoute(handler, {
-  whitelist: navigationWhitelist,
-})
-registerRoute(navigationRoute)
+const baseRouter = createRouter(routes)
+const appShellHandler = createHandlerForURL(findAppShellUrl(self.__WB_MANIFEST))
+
+registerRoute(
+  function match (options) {
+    const {request, url: {pathname}} = options
+
+    if (request && request.mode !== 'navigate') return false
+    const match = baseRouter.matchPath(pathname)
+    if (!match) return false
+
+    const {isClient = true} = routesByName[match.name]
+
+    return isClient
+  },
+
+  async function handle (options) {
+    const {url: {pathname}} = options
+
+    const router = cloneRouter(baseRouter)
+    const routerState = await startRouter(router, pathname)
+
+    const {
+      name,
+      params,
+      meta: {
+        options: {
+          redirected: isRedirect,
+        } = {},
+      } = {},
+    } = routerState
+
+    if (isRedirect) return Response.redirect(router.buildPath(name, params), 302)
+
+    return appShellHandler(options)
+  },
+)
 
 function findAppShellUrl (manifest) {
   for (const {url} of manifest) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6299,11 +6299,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.1.0.tgz#f45a9cc4dc6331ae8f131e0ce4fde8607f802367"
-  integrity sha512-PtHLisEvUOepjc+sStXxJ/pDV/s5UBTOKWJY2SOz3e6E/iN/jLknY9WL72kTwRrwXDUbZTEAtSnJbz2fF127DA==
-
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"


### PR DESCRIPTION
@koden-km Thought you might be interested in this. Managed to actually use router5 properly in the service worker.

It boils down to using [`registerRoute()`] directly, which is a function that takes 2 functions:
- A synchronous "match" function that checks if Workbox should use this route to handle a request
- An asynchronous "handler" function that actually handles the request

Using these two I can set up my own "navigation route" with these cool features:
- Checks that `request.mode` is `'navigate'` (just like [`NavigationRoute`] does)
- Uses the existing router5 route config to decide whether a request should be handled by the service worker at all
- Serves up the pre-cached app shell when it should
- Handles doing *actual* redirects in the service worker in the same way that the server does
- Just works™

[`registerRoute()`]: https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.routing#.registerRoute
[`NavigationRoute`]: https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.routing.NavigationRoute